### PR TITLE
Add Follow-Up Command Center Next.js app and update workspace README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,25 @@
-# Axiom AI Systems Project Hub
+# Axiom Project Workspace
 
-This repo is the command center for Axiom AI Systems projects.
+This repository contains planning docs and project workstreams for multiple Axiom initiatives.
 
-Use this hub to track product ideas, client-facing tools, operating systems, launch tasks, and future standalone repositories.
+## Projects
+- `projects/prospect-builder.md`
+- `projects/client-intake.md`
+- `projects/operations.md`
+- `projects/ai-systems-audit.md`
+- `projects/axiom-site.md`
 
-## Current Projects
+## New Isolated App Workspace
+To avoid interfering with Prospect Builder and other workstreams, the **Axiom Follow-Up Command Center** app now lives in its own isolated project folder:
 
-| Project | Purpose | Status |
-| --- | --- | --- |
-| Prospect Builder | Mobile-first local prospect tracking and outreach helper | Active |
-| Axiom Site | Public-facing brand and offer website | Planned |
-| Client Intake | Intake forms and client onboarding flow | Planned |
-| AI Systems Audit | Repeatable audit process and deliverables | Planned |
-| Operations | Internal workflows, checklists, and business systems | Active |
+- `products/follow-up-command-center/`
 
-## Working Model
+Run it from that folder:
 
-Start projects here while they are small. When an app becomes large enough to stand alone, split it into its own repository and keep this hub as the map.
+```bash
+cd products/follow-up-command-center
+npm install
+npm run dev
+```
 
-Recommended future repo pattern:
-
-- `axiom-prospect-builder`
-- `axiom-site`
-- `axiom-client-intake`
-- `axiom-ai-systems-audit`
-- `axiom-operations`
-
-## Repo Map
-
-- `projects/` contains project briefs and operating notes.
-- `docs/` contains setup, GitHub workflow, and repo-splitting guidance.
-- GitHub Issues are used as the active task board.
-
-## Immediate Priorities
-
-1. Improve Prospect Builder with practical daily prospecting automations.
-2. Create a lightweight Axiom website plan.
-3. Define the AI Systems Audit offer and intake flow.
-4. Build simple operating checklists for daily execution.
+Then open `http://localhost:3000`.

--- a/products/follow-up-command-center/README.md
+++ b/products/follow-up-command-center/README.md
@@ -1,0 +1,34 @@
+# Axiom Follow-Up Command Center (V1)
+
+A practical workflow-first MVP for small business owners to track leads, follow-ups, client requests, and daily tasks in one place.
+
+## Stack
+- Next.js (App Router)
+- React + TypeScript
+- Tailwind CSS
+- localStorage persistence (no backend for V1)
+
+## Features in V1
+- Dashboard summary cards
+- Leads / Follow-Up Tracker
+- Client Request / Task Tracker
+- Message Templates
+- Daily Checklist
+
+## Local setup
+```bash
+npm install
+npm run dev
+```
+
+Open `http://localhost:3000`.
+
+## Project structure
+- `app/layout.tsx`: root layout + metadata
+- `app/page.tsx`: main MVP UI and interactions
+- `app/globals.css`: Tailwind base styles
+- `lib/types.ts`: app data types
+- `lib/seedData.ts`: demo seed data and checklist defaults
+
+## Persistence
+Data saves automatically to browser localStorage key: `axiom-v1`.

--- a/products/follow-up-command-center/app/globals.css
+++ b/products/follow-up-command-center/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-50 text-slate-900;
+}

--- a/products/follow-up-command-center/app/layout.tsx
+++ b/products/follow-up-command-center/app/layout.tsx
@@ -1,0 +1,15 @@
+import "./globals.css";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Axiom Follow-Up Command Center",
+  description: "Simple operations dashboard for leads, follow-ups, and client requests."
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/products/follow-up-command-center/app/page.tsx
+++ b/products/follow-up-command-center/app/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { checklistItems, seedLeads, seedTasks, seedTemplates } from "@/lib/seedData";
+import { Lead, LeadStatus, Priority, Task, TaskStatus, Template } from "@/lib/types";
+
+const leadStatuses: LeadStatus[] = ["New", "Contacted", "Follow-up Needed", "Waiting on Customer", "Won", "Lost"];
+const taskStatuses: TaskStatus[] = ["Not Started", "In Progress", "Waiting", "Completed"];
+const priorities: Priority[] = ["Low", "Medium", "High"];
+
+export default function Home() {
+  const [leads, setLeads] = useState<Lead[]>(seedLeads);
+  const [tasks, setTasks] = useState<Task[]>(seedTasks);
+  const [templates, setTemplates] = useState<Template[]>(seedTemplates);
+  const [checklist, setChecklist] = useState<Record<string, boolean>>({});
+  const [leadFilter, setLeadFilter] = useState<LeadStatus | "All">("All");
+  const [taskFilter, setTaskFilter] = useState<TaskStatus | "All">("All");
+  const [priorityFilter, setPriorityFilter] = useState<Priority | "All">("All");
+
+  useEffect(() => {
+    const saved = localStorage.getItem("axiom-v1");
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      setLeads(parsed.leads ?? seedLeads);
+      setTasks(parsed.tasks ?? seedTasks);
+      setTemplates(parsed.templates ?? seedTemplates);
+      setChecklist(parsed.checklist ?? {});
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("axiom-v1", JSON.stringify({ leads, tasks, templates, checklist }));
+  }, [leads, tasks, templates, checklist]);
+
+  const today = new Date().toISOString().slice(0, 10);
+  const activeLeads = leads.filter((l) => !l.archived && l.status !== "Won" && l.status !== "Lost");
+  const followUpsToday = activeLeads.filter((l) => l.nextFollowUpDate === today).length;
+  const overdueFollowUps = activeLeads.filter((l) => l.nextFollowUpDate < today).length;
+  const openRequests = tasks.filter((t) => t.status !== "Completed").length;
+  const highPriority = tasks.filter((t) => t.priority === "High" && t.status !== "Completed").length;
+
+  const visibleLeads = useMemo(
+    () => [...activeLeads]
+      .filter((lead) => leadFilter === "All" || lead.status === leadFilter)
+      .sort((a, b) => a.nextFollowUpDate.localeCompare(b.nextFollowUpDate)),
+    [activeLeads, leadFilter]
+  );
+
+  const visibleTasks = useMemo(
+    () => tasks.filter((t) => (taskFilter === "All" || t.status === taskFilter) && (priorityFilter === "All" || t.priority === priorityFilter)),
+    [tasks, taskFilter, priorityFilter]
+  );
+
+  return <main className="max-w-7xl mx-auto p-4 md:p-8 space-y-8">
+    <header><h1 className="text-3xl font-bold">Axiom Follow-Up Command Center</h1><p className="text-slate-600">Practical workflow dashboard so nothing important gets missed.</p></header>
+    <section className="grid grid-cols-2 md:grid-cols-5 gap-3">{[["Follow-ups Due Today",followUpsToday],["Overdue Follow-ups",overdueFollowUps],["Open Client Requests",openRequests],["High-Priority Tasks",highPriority],["Active Leads",activeLeads.length]].map(([label,value])=><div key={String(label)} className="bg-white rounded-xl border p-4"><p className="text-sm text-slate-500">{label}</p><p className="text-2xl font-semibold">{Number(value)}</p></div>)}</section>
+
+    <section className="bg-white rounded-xl border p-4 space-y-3"><h2 className="text-xl font-semibold">Leads / Follow-Up Tracker</h2>
+    <div className="flex gap-2 flex-wrap"><select className="border rounded px-2 py-1" value={leadFilter} onChange={(e)=>setLeadFilter(e.target.value as LeadStatus|"All")}><option>All</option>{leadStatuses.map(s=><option key={s}>{s}</option>)}</select><button className="border rounded px-2 py-1" onClick={()=>setLeads([{id:crypto.randomUUID(),name:"",businessName:"",contactInfo:"",leadSource:"",status:"New",lastContactDate:today,nextFollowUpDate:today,priority:"Medium",notes:"",nextAction:""},...leads])}>+ Add Lead</button></div>
+    <div className="space-y-3">{visibleLeads.map(lead=><div key={lead.id} className={`rounded-lg border p-3 ${lead.nextFollowUpDate < today ? "border-red-400 bg-red-50" : ""}`}>
+      <div className="grid md:grid-cols-3 gap-2">{(["name","businessName","contactInfo","leadSource","lastContactDate","nextFollowUpDate","nextAction","notes"] as const).map((f)=><input key={f} className="border rounded px-2 py-1" placeholder={f} value={lead[f]} onChange={(e)=>setLeads(leads.map(l=>l.id===lead.id?{...l,[f]:e.target.value}:l))}/>)}
+      <select className="border rounded px-2 py-1" value={lead.status} onChange={(e)=>setLeads(leads.map(l=>l.id===lead.id?{...l,status:e.target.value as LeadStatus}:l))}>{leadStatuses.map(s=><option key={s}>{s}</option>)}</select>
+      <select className="border rounded px-2 py-1" value={lead.priority} onChange={(e)=>setLeads(leads.map(l=>l.id===lead.id?{...l,priority:e.target.value as Priority}:l))}>{priorities.map(s=><option key={s}>{s}</option>)}</select></div>
+      <div className="mt-2"><button className="text-sm text-slate-600 mr-3" onClick={()=>setLeads(leads.map(l=>l.id===lead.id?{...l,archived:true}:l))}>Archive</button><button className="text-sm text-red-600" onClick={()=>setLeads(leads.filter(l=>l.id!==lead.id))}>Delete</button></div>
+    </div>)}</div></section>
+
+    <section className="bg-white rounded-xl border p-4 space-y-3"><h2 className="text-xl font-semibold">Client Request / Task Tracker</h2>
+    <div className="flex gap-2 flex-wrap"><select className="border rounded px-2 py-1" value={taskFilter} onChange={(e)=>setTaskFilter(e.target.value as TaskStatus|"All")}><option>All</option>{taskStatuses.map(s=><option key={s}>{s}</option>)}</select><select className="border rounded px-2 py-1" value={priorityFilter} onChange={(e)=>setPriorityFilter(e.target.value as Priority|"All")}><option>All</option>{priorities.map(s=><option key={s}>{s}</option>)}</select><button className="border rounded px-2 py-1" onClick={()=>setTasks([{id:crypto.randomUUID(),title:"",relatedClient:"",dueDate:today,priority:"Medium",status:"Not Started",notes:""},...tasks])}>+ Add Task</button></div>
+    {visibleTasks.map(task=><div key={task.id} className={`rounded-lg border p-3 ${task.dueDate<today && task.status!=="Completed"?"border-red-400 bg-red-50":""}`}><div className="grid md:grid-cols-3 gap-2">{(["title","relatedClient","dueDate","notes"] as const).map((f)=><input key={f} className="border rounded px-2 py-1" value={task[f]} placeholder={f} onChange={(e)=>setTasks(tasks.map(t=>t.id===task.id?{...t,[f]:e.target.value}:t))}/>)}<select className="border rounded px-2 py-1" value={task.priority} onChange={(e)=>setTasks(tasks.map(t=>t.id===task.id?{...t,priority:e.target.value as Priority}:t))}>{priorities.map(s=><option key={s}>{s}</option>)}</select><select className="border rounded px-2 py-1" value={task.status} onChange={(e)=>setTasks(tasks.map(t=>t.id===task.id?{...t,status:e.target.value as TaskStatus}:t))}>{taskStatuses.map(s=><option key={s}>{s}</option>)}</select></div><button className="text-sm text-emerald-700 mt-2 mr-3" onClick={()=>setTasks(tasks.map(t=>t.id===task.id?{...t,status:"Completed"}:t))}>Mark Complete</button></div>)}
+    </section>
+
+    <section className="bg-white rounded-xl border p-4 space-y-3"><h2 className="text-xl font-semibold">Message Templates</h2>{templates.map(template=><div key={template.id} className="border rounded p-3 space-y-2"><input className="border rounded px-2 py-1 w-full" value={template.name} onChange={(e)=>setTemplates(templates.map(t=>t.id===template.id?{...t,name:e.target.value}:t))}/><textarea className="border rounded px-2 py-1 w-full min-h-24" value={template.body} onChange={(e)=>setTemplates(templates.map(t=>t.id===template.id?{...t,body:e.target.value}:t))}/><button className="text-sm text-blue-700" onClick={()=>navigator.clipboard.writeText(template.body)}>Copy template</button></div>)}</section>
+
+    <section className="bg-white rounded-xl border p-4"><h2 className="text-xl font-semibold mb-3">Daily Checklist</h2><div className="space-y-2">{checklistItems.map(item=><label key={item} className="flex items-center gap-2"><input type="checkbox" checked={Boolean(checklist[item])} onChange={()=>setChecklist({...checklist,[item]:!checklist[item]})}/><span>{item}</span></label>)}</div></section>
+  </main>;
+}

--- a/products/follow-up-command-center/lib/seedData.ts
+++ b/products/follow-up-command-center/lib/seedData.ts
@@ -1,0 +1,37 @@
+import { Lead, Task, Template } from "./types";
+
+const today = new Date();
+const day = (offset: number) => {
+  const d = new Date(today);
+  d.setDate(d.getDate() + offset);
+  return d.toISOString().slice(0, 10);
+};
+
+export const seedLeads: Lead[] = [
+  { id: "l1", name: "Sarah Jennings", businessName: "Jennings Bakery", contactInfo: "sarah@jbakery.com", leadSource: "Website Form", status: "Follow-up Needed", lastContactDate: day(-4), nextFollowUpDate: day(-1), priority: "High", notes: "Needs catering estimate for office event", nextAction: "Send revised estimate" },
+  { id: "l2", name: "Carlos Diaz", businessName: "Diaz Landscaping", contactInfo: "(555) 913-4421", leadSource: "Referral", status: "Contacted", lastContactDate: day(-1), nextFollowUpDate: day(1), priority: "Medium", notes: "Interested in monthly admin support", nextAction: "Share onboarding checklist" }
+];
+
+export const seedTasks: Task[] = [
+  { id: "t1", title: "Send proposal draft", relatedClient: "Jennings Bakery", dueDate: day(0), priority: "High", status: "In Progress", notes: "Include optional weekend support" },
+  { id: "t2", title: "Confirm follow-up call", relatedClient: "Diaz Landscaping", dueDate: day(-2), priority: "Medium", status: "Not Started", notes: "Morning slot preferred" }
+];
+
+export const seedTemplates: Template[] = [
+  { id: "m1", name: "First response to new lead", body: "Hi [Name], thanks for reaching out to us. I’d love to help. Can we schedule a quick 15-minute call this week to understand what you need?" },
+  { id: "m2", name: "Follow-up after no reply", body: "Hi [Name], just checking in in case my previous message got buried. Are you still looking for support with [need]?" },
+  { id: "m3", name: "Appointment reminder", body: "Hi [Name], friendly reminder about our appointment on [Date/Time]. Reply here if you need to reschedule." },
+  { id: "m4", name: "Estimate follow-up", body: "Hi [Name], I wanted to follow up on the estimate I sent over. Happy to answer questions or make any adjustments." },
+  { id: "m5", name: "Thank-you message", body: "Thanks again, [Name]. We appreciate your business and look forward to supporting you." },
+  { id: "m6", name: "Re-engagement message", body: "Hi [Name], it’s been a little while. If you still need help with [service], I’d be glad to pick this back up with you." }
+];
+
+export const checklistItems = [
+  "Check new leads",
+  "Review overdue follow-ups",
+  "Review follow-ups due today",
+  "Review open client requests",
+  "Complete or update high-priority tasks",
+  "Send needed messages",
+  "Set next follow-up dates"
+];

--- a/products/follow-up-command-center/lib/types.ts
+++ b/products/follow-up-command-center/lib/types.ts
@@ -1,0 +1,31 @@
+export type LeadStatus = "New" | "Contacted" | "Follow-up Needed" | "Waiting on Customer" | "Won" | "Lost";
+export type Priority = "Low" | "Medium" | "High";
+
+export type Lead = {
+  id: string;
+  name: string;
+  businessName: string;
+  contactInfo: string;
+  leadSource: string;
+  status: LeadStatus;
+  lastContactDate: string;
+  nextFollowUpDate: string;
+  priority: Priority;
+  notes: string;
+  nextAction: string;
+  archived?: boolean;
+};
+
+export type TaskStatus = "Not Started" | "In Progress" | "Waiting" | "Completed";
+
+export type Task = {
+  id: string;
+  title: string;
+  relatedClient: string;
+  dueDate: string;
+  priority: Priority;
+  status: TaskStatus;
+  notes: string;
+};
+
+export type Template = { id: string; name: string; body: string };

--- a/products/follow-up-command-center/next-env.d.ts
+++ b/products/follow-up-command-center/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/products/follow-up-command-center/next.config.ts
+++ b/products/follow-up-command-center/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/products/follow-up-command-center/package.json
+++ b/products/follow-up-command-center/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "axiom-follow-up-command-center",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "16.0.1",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "22.15.17",
+    "@types/react": "19.2.2",
+    "@types/react-dom": "19.2.2",
+    "autoprefixer": "10.4.21",
+    "eslint": "9.26.0",
+    "eslint-config-next": "16.0.1",
+    "postcss": "8.5.3",
+    "tailwindcss": "3.4.17",
+    "typescript": "5.8.3"
+  }
+}

--- a/products/follow-up-command-center/postcss.config.js
+++ b/products/follow-up-command-center/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/products/follow-up-command-center/tailwind.config.ts
+++ b/products/follow-up-command-center/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/products/follow-up-command-center/tsconfig.json
+++ b/products/follow-up-command-center/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, isolated MVP for tracking leads, follow-ups, client requests, and daily tasks without affecting existing Prospect Builder work.
- Make the new app easy to run locally and keep the hub repo as a map of project workstreams.

### Description
- Replace the top-level README with an updated workspace overview and add a link and run instructions for the new product folder `products/follow-up-command-center/`.
- Add a self-contained Next.js + TypeScript + Tailwind V1 app under `products/follow-up-command-center/` including `app/layout.tsx`, `app/page.tsx`, global styles, and metadata.
- Add app support files and configuration including `package.json`, `tsconfig.json`, `next.config.ts`, `postcss.config.js`, `tailwind.config.ts`, and `next-env.d.ts`.
- Add domain types and demo data under `lib/` with `types.ts`, `seedData.ts`, and use browser `localStorage` key `axiom-v1` for persistence.

### Testing
- No automated tests were added or executed as part of this change.  Manual local run instructions are provided: `cd products/follow-up-command-center && npm install && npm run dev`, then open `http://localhost:3000`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ab903770832abf30aedf8a282af8)