### PR TITLE
Ensure Follow-Up Command Center demo shows due-today follow-up

### DIFF
--- a/products/follow-up-command-center/eslint.config.mjs
+++ b/products/follow-up-command-center/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  globalIgnores([
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts"
+  ])
+]);
+
+export default eslintConfig;

--- a/products/follow-up-command-center/lib/seedData.ts
+++ b/products/follow-up-command-center/lib/seedData.ts
@@ -9,7 +9,8 @@ const day = (offset: number) => {
 
 export const seedLeads: Lead[] = [
   { id: "l1", name: "Sarah Jennings", businessName: "Jennings Bakery", contactInfo: "sarah@jbakery.com", leadSource: "Website Form", status: "Follow-up Needed", lastContactDate: day(-4), nextFollowUpDate: day(-1), priority: "High", notes: "Needs catering estimate for office event", nextAction: "Send revised estimate" },
-  { id: "l2", name: "Carlos Diaz", businessName: "Diaz Landscaping", contactInfo: "(555) 913-4421", leadSource: "Referral", status: "Contacted", lastContactDate: day(-1), nextFollowUpDate: day(1), priority: "Medium", notes: "Interested in monthly admin support", nextAction: "Share onboarding checklist" }
+  { id: "l2", name: "Carlos Diaz", businessName: "Diaz Landscaping", contactInfo: "(555) 913-4421", leadSource: "Referral", status: "Contacted", lastContactDate: day(-1), nextFollowUpDate: day(1), priority: "Medium", notes: "Interested in monthly admin support", nextAction: "Share onboarding checklist" },
+  { id: "l3", name: "Maya Thompson", businessName: "Thompson Cleaning Co.", contactInfo: "maya@thompsoncleaning.com", leadSource: "Referral", status: "Follow-up Needed", lastContactDate: day(-2), nextFollowUpDate: day(0), priority: "High", notes: "Asked about recurring office cleaning support", nextAction: "Confirm available walkthrough times" }
 ];
 
 export const seedTasks: Task[] = [
@@ -18,12 +19,12 @@ export const seedTasks: Task[] = [
 ];
 
 export const seedTemplates: Template[] = [
-  { id: "m1", name: "First response to new lead", body: "Hi [Name], thanks for reaching out to us. I’d love to help. Can we schedule a quick 15-minute call this week to understand what you need?" },
+  { id: "m1", name: "First response to new lead", body: "Hi [Name], thanks for reaching out to us. I'd love to help. Can we schedule a quick 15-minute call this week to understand what you need?" },
   { id: "m2", name: "Follow-up after no reply", body: "Hi [Name], just checking in in case my previous message got buried. Are you still looking for support with [need]?" },
   { id: "m3", name: "Appointment reminder", body: "Hi [Name], friendly reminder about our appointment on [Date/Time]. Reply here if you need to reschedule." },
   { id: "m4", name: "Estimate follow-up", body: "Hi [Name], I wanted to follow up on the estimate I sent over. Happy to answer questions or make any adjustments." },
   { id: "m5", name: "Thank-you message", body: "Thanks again, [Name]. We appreciate your business and look forward to supporting you." },
-  { id: "m6", name: "Re-engagement message", body: "Hi [Name], it’s been a little while. If you still need help with [service], I’d be glad to pick this back up with you." }
+  { id: "m6", name: "Re-engagement message", body: "Hi [Name], it's been a little while. If you still need help with [service], I'd be glad to pick this back up with you." }
 ];
 
 export const checklistItems = [

--- a/products/follow-up-command-center/package.json
+++ b/products/follow-up-command-center/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "next": "16.0.1",


### PR DESCRIPTION
### Summary
- Keep the existing Axiom Follow-Up Command Center V1 app intact.
- Add one seed lead with a follow-up due today so the dashboard visibly demonstrates the due-today workflow on a fresh localStorage state.
- Update the lint script for Next.js 16 by using the ESLint CLI and adding a flat ESLint config.

### Verification
- GitHub reports this PR as mergeable against `main`.
- Static inspection confirms the original V1 app is already present on `main`, and this branch is now only the small V1 demo/checks cleanup.
- No GitHub Actions checks are configured for this commit.
- Local command execution is currently blocked in the Codex desktop Windows sandbox, so `npm install`, `npm run lint`, and `npm run build` still need to be run locally.
